### PR TITLE
Fix release workflow signing key password

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
         with:
           tagName: v__VERSION__
           releaseName: "Orca v__VERSION__"


### PR DESCRIPTION
## Summary
- Add empty `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` env var to the release workflow
- The signing key was generated without a password, but Tauri requires the env var to be set (even if empty) to avoid "Wrong password for that key" errors

## Test plan
- [x] Verified the build compiles and creates .dmg successfully (failed only at signing step)
- [ ] Merge, re-tag v0.2.0, and verify release workflow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)