### PR TITLE
Regenerate signing key with password

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           tagName: v__VERSION__
           releaseName: "Orca v__VERSION__"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -40,7 +40,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEM5MDY5N0U3MTMxNUFDN0YKUldSL3JCVVQ1NWNHeVMweFVad0w0UkJaaXhURlg1TlJodFFFalhWNnJ2RWlBY0lNek5PTWZkekgK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDVFREM5RUFGRTVEQjBDRTAKUldUZ0ROdmxyNTdjWHR6eXNUQWIvdWNGWFYvTE5HdGlpamlEbGF4c1hsOHREUFBOb2hrQ3N0Q2gK",
       "endpoints": ["https://github.com/beaufour/orca/releases/latest/download/latest.json"]
     }
   }


### PR DESCRIPTION
## Summary
- Regenerated Tauri updater signing key with a proper password
- Updated pubkey in `tauri.conf.json`
- Pass `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` from GitHub secrets in the release workflow
- Updated both `TAURI_SIGNING_PRIVATE_KEY` and `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` GitHub secrets

## Test plan
- [ ] Merge, re-tag v0.1.0, verify release workflow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)